### PR TITLE
fix: remove highlights when clearing chat

### DIFF
--- a/src/js/sidebar.js
+++ b/src/js/sidebar.js
@@ -282,6 +282,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         renderPopupUI();
         updateStatus("Chat cleared. Ask a new question.", "idle");
       }
+      handleRemoveHighlights();
       closeSettingsDropdown();
     });
   }


### PR DESCRIPTION
Fixes #4 

I added the handleRemoveHighlights() function to the click event listener for the Clear Chat button.