### PR TITLE
Implement working general knowledge ai mode

### DIFF
--- a/src/html/sidebar.html
+++ b/src/html/sidebar.html
@@ -720,6 +720,16 @@
                   <span class="toggle-slider"></span>
                 </div>
               </div>
+              <div
+                class="settings-dropdown-item"
+                id="toggleGeneralKnowledgeDropdownItem"
+              >
+                <span id="generalKnowledgeToggleText">General Knowledge</span>
+                <div class="toggle-switch">
+                  <input type="checkbox" id="generalKnowledgeToggle" checked />
+                  <span class="toggle-slider"></span>
+                </div>
+              </div>
             </div>
           </button>
         </div>
@@ -735,8 +745,6 @@
             <span id="numCitationsValue">3</span>
           </div>
         </div>
-        <!-- The old "Clear Highlights" button can be removed if dropdown is preferred -->
-        <!-- <button id="removeHighlights" class="secondary-button danger" title="Remove Highlights from Page">Clear Highlights</button> -->
       </div>
 
       <div id="status" class="status">Enter a query to start.</div>
@@ -798,9 +806,7 @@
           </div>
         </div>
         <div class="citations-content-wrapper" id="citationsContentWrapper">
-          <div id="citationsContainer" class="citations-container">
-            <!-- Citations will be dynamically inserted here -->
-          </div>
+          <div id="citationsContainer" class="citations-container"></div>
           <div class="button-group" id="citationNavButtons">
             <button id="prevMatch" class="nav-button" disabled>
               Previous Citation

--- a/src/html/sidebar.html
+++ b/src/html/sidebar.html
@@ -20,7 +20,7 @@
         --transition: all 0.2s ease;
         --highlight-bg: rgba(99, 102, 241, 0.4);
         --user-message-bg: var(--primary);
-        --assistant-message-bg: var(--bg-light); /* Or #2a2a2a as you had */
+        --assistant-message-bg: var(--bg-light);
       }
 
       body {
@@ -31,7 +31,7 @@
         color: var(--text-primary);
         background-color: var(--bg-dark);
         margin: 0;
-        height: 95vh; /* Ensure body takes up height */
+        height: 95vh;
         display: flex;
         flex-direction: column;
       }
@@ -39,10 +39,10 @@
       .container {
         display: flex;
         flex-direction: column;
-        gap: 10px; /* Adjusted gap slightly */
-        flex: 1; /* Allow container to grow and shrink */
-        min-height: 0; /* Important for flex children that scroll */
-        height: 100%; /* Take full height of body's flex context */
+        gap: 10px;
+        flex: 1;
+        min-height: 0;
+        height: 100%;
       }
 
       .header {
@@ -68,7 +68,6 @@
       }
 
       .settings-icon-wrapper {
-        /* Added wrapper for better positioning control of dropdown */
         position: relative;
       }
 
@@ -98,7 +97,7 @@
 
       .settings-dropdown {
         position: absolute;
-        top: calc(100% + 4px); /* Position below the icon with a small gap */
+        top: calc(100% + 4px);
         right: 0;
         background-color: var(--bg-light);
         border-radius: var(--border-radius);
@@ -155,7 +154,6 @@
         margin: 4px 0;
       }
 
-      /* Toggle Switch Styles */
       .toggle-switch {
         position: relative;
         display: inline-block;
@@ -199,11 +197,9 @@
       }
 
       .extension-controls {
-        /* This holds the Max Citations slider now */
         display: flex;
         flex-direction: column;
         gap: 8px;
-        /* margin-bottom: 8px; */ /* Removed as container has gap */
         flex-shrink: 0;
       }
 
@@ -265,7 +261,6 @@
         border-radius: var(--border-radius);
         display: none;
         transition: var(--transition);
-        /* margin: 0 0 8px 0; */ /* Removed as container has gap */
         font-weight: 500;
         letter-spacing: 0.3px;
         flex-shrink: 0;
@@ -299,15 +294,13 @@
         flex: 1;
         min-height: 0;
         overflow-y: auto;
-        padding: 10px; /* Adjusted padding */
-        background-color: var(--bg-dark); /* Kept your background */
+        padding: 10px;
+        background-color: var(--bg-dark);
         border-radius: var(--border-radius);
         display: flex;
         flex-direction: column;
-        gap: 12px; /* Increased gap between messages */
+        gap: 12px;
         border: none;
-        /* margin-bottom: 8px; */ /* Removed as container has gap */
-        /* height: calc(100vh - 200px); */ /* This can be problematic, flex:1 is better */
       }
 
       .chat-log-container:empty::before {
@@ -329,23 +322,22 @@
         font-size: 14px;
         line-height: 1.5;
         white-space: pre-wrap;
-        /* margin: 4px 0; */ /* Removed as parent has gap */
       }
 
       .user-message {
         background-color: var(--user-message-bg);
-        color: white; /* Explicitly white */
+        color: white;
         align-self: flex-end;
         border-bottom-right-radius: 4px;
-        margin-left: 15%; /* Ensure it doesn't take full width */
+        margin-left: 15%;
       }
 
       .assistant-message {
-        background-color: #2a2a2a; /* Your preferred assistant bg */
+        background-color: #2a2a2a;
         color: var(--text-primary);
         align-self: flex-start;
         border-bottom-left-radius: 4px;
-        margin-right: 15%; /* Ensure it doesn't take full width */
+        margin-right: 15%;
       }
 
       .assistant-message.has-citations {
@@ -385,14 +377,55 @@
         }
       }
 
+      .general-knowledge-prompt-container {
+        margin-top: 12px;
+        padding-top: 8px;
+        border-top: 1px solid var(--bg-light);
+      }
+      .general-knowledge-prompt-button {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 12px;
+        font-size: 12px;
+        font-weight: 500;
+        border-radius: 16px;
+        border: 1px solid var(--primary);
+        background-color: transparent;
+        color: var(--primary);
+        cursor: pointer;
+        transition: var(--transition);
+        font-family: inherit;
+        line-height: 1;
+      }
+      .general-knowledge-prompt-button:hover:not(:disabled) {
+        background-color: rgba(99, 102, 241, 0.15);
+        border-color: var(--primary-dark);
+      }
+      .general-knowledge-prompt-button:disabled {
+        opacity: 0.7;
+        cursor: not-allowed;
+        background-color: transparent;
+      }
+      .general-knowledge-prompt-button svg {
+        width: 14px;
+        height: 14px;
+        flex-shrink: 0;
+      }
+      .general-knowledge-prompt-button .spinner {
+        width: 14px;
+        height: 14px;
+        border-top-color: var(--primary);
+        border-width: 2px;
+      }
+
       .input-container {
         display: flex;
         align-items: center;
         gap: 8px;
         background-color: var(--bg-light);
         padding: 8px 12px;
-        border-radius: 20px; /* iOS like */
-        /* margin-top: 8px; */ /* Removed as container has gap */
+        border-radius: 20px;
         border: 1px solid rgba(255, 255, 255, 0.1);
         flex-shrink: 0;
       }
@@ -403,7 +436,7 @@
         border: none;
         color: var(--text-primary);
         font-size: 14px;
-        padding: 8px 0; /* Adjust padding if needed */
+        padding: 8px 0;
         outline: none;
       }
       #searchQuery::placeholder {
@@ -422,7 +455,7 @@
         justify-content: center;
         cursor: pointer;
         transition: var(--transition);
-        padding: 0; /* Remove default button padding */
+        padding: 0;
         flex-shrink: 0;
       }
       #searchButton svg {
@@ -441,7 +474,7 @@
       }
       #searchButton.loading svg {
         display: none;
-      } /* Hide SVG when spinner is active */
+      }
       .spinner {
         display: none;
         width: 16px;
@@ -458,7 +491,6 @@
       }
 
       .citations-section {
-        /* Wrapper for collapsibility */
         flex-shrink: 0;
       }
       .citations-header {
@@ -466,7 +498,7 @@
         align-items: center;
         justify-content: space-between;
         cursor: pointer;
-        padding: 8px 4px; /* Consistent padding */
+        padding: 8px 4px;
         user-select: none;
         border-radius: var(--border-radius);
       }
@@ -493,8 +525,7 @@
       }
 
       .citations-content-wrapper {
-        /* This will collapse */
-        max-height: 280px; /* Includes container and nav buttons, adjust as needed */
+        max-height: 280px;
         overflow: hidden;
         transition: max-height 0.3s ease-out;
       }
@@ -506,11 +537,11 @@
         background-color: var(--bg-light);
         border-radius: var(--border-radius);
         padding: 8px;
-        margin-bottom: 8px; /* Gap before nav buttons */
-        max-height: 160px; /* Max height for scrolling *within* this container */
+        margin-bottom: 8px;
+        max-height: 160px;
         overflow-y: auto;
         border: 1px solid var(--primary-dark);
-        min-height: 60px; /* Adjusted min-height */
+        min-height: 60px;
         display: flex;
         flex-direction: column;
       }
@@ -601,7 +632,7 @@
         font-size: 12px;
         color: var(--text-secondary);
         padding: 16px 0 0 0;
-        margin-top: auto; /* Pushes to bottom if container not full */
+        margin-top: auto;
         display: flex;
         align-items: center;
         justify-content: center;


### PR DESCRIPTION
Implements #5 

- New general knowledge toggle which allows LLM to use external sources when enabled
- Checks current page text first, and if no relevant content found, checks external sources
- UI indicates whether answer came from page or general knowledge
- Citations still function as before, except no citations for general knowledge answers
- When disabled, only use page content as context
- Prompts user to use general knowledge mode when disabled

<img width="1552" alt="Screenshot 2025-06-06 at 2 34 15 PM" src="https://github.com/user-attachments/assets/51e15533-2516-4946-b20b-1bb85870b97d" />
<img width="340" alt="Screenshot 2025-06-06 at 2 34 36 PM" src="https://github.com/user-attachments/assets/ab835f1f-5f2e-45f8-9cf7-5f8f37303cea" />
<img width="340" alt="Screenshot 2025-06-06 at 2 34 49 PM" src="https://github.com/user-attachments/assets/5ea31368-525c-4af6-82b4-dc21a3f8f410" />
